### PR TITLE
Escape XML characters

### DIFF
--- a/package-dom.lisp
+++ b/package-dom.lisp
@@ -94,7 +94,8 @@
    #:serialize-object
    #:traverse
    #:trim
-   #:strip)
+   #:strip
+   #:xml-character-p)
   ;; entities.lisp
   (:export
    #:*entity-map*


### PR DESCRIPTION
This is a very preliminary pull request to give some focus to the discussion in #3. 

I've used simple errors here, to keep things obvious, but if something like this is going to be part of the API then the errors should be signaled as distinguished conditions. 

I don't understand the usefulness of distinguishing between disallowed and discouraged characters. Discouraged characters are discouraged for very good reason -- most parsers don't support them -- CXML, for example, or anything that uses libxml2. It would also at least double the number of tests per character.

This is just a starting point; I'm happy to make any further changes.