### PR TITLE
*stream* should track cl:*standard-output*

### DIFF
--- a/dom.lisp
+++ b/dom.lisp
@@ -587,21 +587,17 @@ attribute."
     (scanren node))
   NIL)
 
-(defvar *stream* *standard-output*
+(defvar *stream* (make-synonym-stream 'cl:*standard-output*)
   "The stream to serialize to during SERIALIZE-OBJECT.")
 
-(defun serialize (node &optional (stream T))
+(defun serialize (node &optional (stream *stream*))
   "Serializes NODE to STREAM.
 STREAM can be a stream, T for *standard-output* or NIL to serialize to string."
-  (cond ((eql stream T)
-         (let ((*stream* *standard-output*))
-           (serialize-object node)))
-        ((eql stream NIL)
-         (with-output-to-string (*stream*)
-           (serialize-object node)))
-        (T
-         (let ((*stream* stream))
-           (serialize-object node)))))
+  (if (null stream)
+      (with-output-to-string (*stream*)
+        (serialize-object node))
+      (let ((*stream* *stream*))
+        (serialize-object node))))
 
 (macrolet ((wrs (&rest strings)
               `(progn


### PR DESCRIPTION
While helping out someone over at #lisp I saw a subtle bug with serialize. It is even more subtle because serialize doesn't use `*stream*` default value by default. Below is a test case illustrating the bug.

```lisp
;; (ql:quickload :plump)
(ql:quickload :plump :silent t)

(ql:quickload :drakma)
(defvar *root* (plump:parse (babel:octets-to-string (drakma:http-request "http://adndevblog.typepad.com/autocad/rss.xml"))))

(plump:serialize *root*)
(plump:serialize *root* plump:*stream*) ; <- Doesn't write to the standard-output
(plump:serialize *root* nil)
```

Related: http://lisptips.com/post/127524780849/when-a-synonym-stream-is-useful