### PR TITLE
Fix error when lexing <!--> and <!--->

### DIFF
--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -48,7 +48,7 @@
    (decode-entities
     (if (and (ends-with "--" name)
              (char= (or (peek) #\!) #\>))
-        (prog1 (subseq name 3 (- (length name) 2))
+        (prog1 (subseq name 3 (max 3 (- (length name) 2)))
           (advance))
         (prog1 (concatenate
                 'string (subseq name 3)


### PR DESCRIPTION
Previously, the code assumed the length of the name of the tag would be
at least 5, but that's not true in these two (invalid) cases. Browsers
treat them as empty comments, and this change makes Plump do so too.