### PR TITLE
Ensure correct loading of character entity references on LispWorks

### DIFF
--- a/entities.lisp
+++ b/entities.lisp
@@ -1,3 +1,4 @@
+;;;; -*- coding: utf-8  -*-
 #|
  This file is a part of Plump
  (c) 2014 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)


### PR DESCRIPTION
The library fails to load as LispWorks cannot cope with the contents of
`*entity-map*`.

Adding the encoding option to the source file fixes this, both when loading and
editing the file. I am not aware of a less intrusive way to fix this.

This commit hopefully fixes issue #18. Tested on LispWorks 7.1.2 64bit on macOS.