### PR TITLE
Fix <hr> being defined as a grouping element

### DIFF
--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -143,7 +143,7 @@
 
 (macrolet ((define-all (&rest tags)
              `(progn ,@(loop for tag in tags collect `(define-grouping-element ,tag *tag-dispatchers* *html-tags*)))))
-  (define-all blockquote dd dir div span dl dt figcaption figure hr li main ol p pre ul code pre i iframe))
+  (define-all blockquote dd dir div span dl dt figcaption figure li main ol p pre ul code pre i iframe))
 
 (defun read-fulltext-element-content (name)
   (with-output-to-string (out)


### PR DESCRIPTION
It is defined as a self-closing element, which is correct, but then it was redefined as a grouping element, which is incorrect.