### PR TITLE
Fix <a> not being defined as a grouping element

### DIFF
--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -143,7 +143,7 @@
 
 (macrolet ((define-all (&rest tags)
              `(progn ,@(loop for tag in tags collect `(define-grouping-element ,tag *tag-dispatchers* *html-tags*)))))
-  (define-all blockquote dd dir div span dl dt figcaption figure li main ol p pre ul code pre i iframe))
+  (define-all blockquote dd dir div span dl dt figcaption figure li main ol p pre ul code pre i iframe a))
 
 (defun read-fulltext-element-content (name)
   (with-output-to-string (out)


### PR DESCRIPTION
Without this, Plump can generate an empty `<a>` as `<a href="#"/>`, which is interpreted by browsers as just a starting tag.

It's not entirely clear to me what the scope of "grouping elements" is, but since `<i>` is in there I figured `<a>` would fit as well.