### PR TITLE
Use Generic Wild Card Tag Dispatcher

### DIFF
--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -126,6 +126,7 @@
 
 ;; wildcard dispatcher
 (define-tag-dispatcher (* *tag-dispatchers* *html-tags*) (name)
+  (declare (ignore name))
   ;; match everything
   T)
 ;; default html5 behavior

--- a/tag-dispatcher.lisp
+++ b/tag-dispatcher.lisp
@@ -18,7 +18,8 @@
   (printer (lambda (a) (declare (ignore a)) NIL) :type (function (T) boolean)))
 
 (defun tag-dispatcher (name &optional (list *all-tag-dispatchers*))
-  (find name list :key #'tag-dispatcher-name))
+  (or (find name list :key #'tag-dispatcher-name)
+      (find '* list :key #'tag-dispatcher-name)))
 
 (define-setf-expander tag-dispatcher (name &optional (list '*all-tag-dispatchers*))
   (let ((nameg (gensym "NAME"))

--- a/tag-dispatcher.lisp
+++ b/tag-dispatcher.lisp
@@ -18,17 +18,20 @@
   (printer (lambda (a) (declare (ignore a)) NIL) :type (function (T) boolean)))
 
 (defun tag-dispatcher (name &optional (list *all-tag-dispatchers*))
-  (or (find name list :key #'tag-dispatcher-name)
-      (find '* list :key #'tag-dispatcher-name)))
+  (find name list :key #'tag-dispatcher-name))
 
 (define-setf-expander tag-dispatcher (name &optional (list '*all-tag-dispatchers*))
-  (let ((nameg (gensym "NAME"))
-        (disp (gensym "DISP")))
+  (let* ((nameg (gensym "NAME"))
+         (disp (gensym "DISP"))
+         (removed (gensym)))
     (values (list nameg)
             (list name)
             (list disp)
-            `(progn
-               (setf ,list (list* ,disp (remove ,nameg ,list :key #'tag-dispatcher-name)))
+            `(let ((,removed (remove ,nameg ,list :key #'tag-dispatcher-name)))
+               (setf ,list
+                     (if (eq '* ,nameg)
+                         (append ,removed (list ,disp))
+                         (list* ,disp ,removed)))
                ,disp)
             disp)))
 


### PR DESCRIPTION
A wild card dispatcher has a name `*` and will match any tag. It is always at the end of a dispatcher list. This allows you to define a default behavior for a "mode"; the default behavior for tags in html-mode is whatever the wild card dispatcher is in `*html-tags*`.

 I defined one for html-mode because it looks like you defined your library to already do xml-mode by default. This causes issues when using non-standard html tags as described in the [the html standard](https://html.spec.whatwg.org/multipage/syntax.html#start-tags) and on [stack overflow](https://stackoverflow.com/questions/3558119/are-non-void-self-closing-tags-valid-in-html5#3558200).

> On other HTML elements, the slash is an error, but error recovery will cause browsers to ignore it and treat the tag as a regular start tag. This will usually end up with a missing end tag causing subsequent elements to be children instead of siblings.

It would be fine if your library used xml printing as standard, but in your readme:
> By default self-closing tags will be printed in "HTML-fashion,"

It works usually, but for non-standard tags it still resorts to xml parsing:
```lisp
;; before my changes
(let ((plump:*tag-dispatchers* plump:*html-tags*))
  (plump:serialize (plump:parse "<non-standard>")))
;=> <non-standard/>
```

```lisp
;; after my changes
(let ((plump:*tag-dispatchers* plump:*html-tags*))
  (plump:serialize (plump:parse "<non-standard>")))
;=> <non-standard></non-standard>
```