### PR TITLE
DEFINE-WILDCARD-DISPATCHER macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ If you don't want to disturb the standard Plump tag dispatchers list, you can de
     (plump:define-self-closing-element img *tag-dispatchers* *html-tags*)
     (plump:define-fulltext-element style *tag-dispatchers* *html-tags*)
 
+You can also define a wild card dispatcher for your own special variable that will dispatch on any tag that doesn't match another dispatcher:
+
+    (plump:define-wildcard-dispatcher your-default *your-special-variable*)
+
 XML allows for script tags (like `<?php ?>`). By default Plump does not specify any special reading for any script tag. If an unhandled script tag is encountered, a warning is emitted and Plump will try to just read anything until `?>` is encountered. For most script tags this probably will not suffice, as they might contain some form of escaped `?>`. If you do want to use Plump to process script tags properly as well, you will have to define your own reader with `define-processing-parser`. You can also use that macro to define a reader that outputs a more suitable format than a text tag.
 
 During parsing, all elements are created through `MAKE-*` functions like `MAKE-ROOT`, `MAKE-ELEMENT`, `MAKE-TEXT-NODE`, and so on. By overriding these functions you can instead delegate the parsing to your own DOM.

--- a/package.lisp
+++ b/package.lisp
@@ -176,6 +176,7 @@
    #:tag-dispatcher
    #:remove-tag-dispatcher
    #:define-tag-dispatcher
+   #:define-wildcard-dispatcher
    #:define-tag-parser
    #:define-tag-printer
    #:do-tag-parsers

--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -126,6 +126,7 @@
 
 ;; wildcard dispatcher
 (define-tag-dispatcher (* *tag-dispatchers* *html-tags*) (name)
+  (declare (ignore name))
   ;; match everything
   T)
 ;; default html5 behavior

--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -125,12 +125,9 @@
   (define-all area base br col embed hr img input keygen link menuitem meta param source track wbr))
 
 ;; wildcard dispatcher
-(define-tag-dispatcher (* *tag-dispatchers* *html-tags*) (name)
-  (declare (ignore name))
-  ;; match everything
-  T)
+(define-wildcard-dispatcher html-default *tag-dispatchers* *html-tags*)
 ;; default html5 behavior
-(define-tag-printer * (node)
+(define-tag-printer html-default (node)
   (plump-dom::wrs "<" (tag-name node))
   (serialize (attributes node) *stream*)
   (plump-dom::wrs ">")
@@ -138,7 +135,7 @@
         do (serialize child *stream*))
   (plump-dom::wrs "</" (tag-name node) ">")
   T)
-(define-tag-parser * (name)
+(define-tag-parser html-default (name)
   (read-standard-tag name))
 
 (defun read-fulltext-element-content (name)

--- a/tag-dispatcher.lisp
+++ b/tag-dispatcher.lisp
@@ -18,7 +18,8 @@
   (printer (lambda (a) (declare (ignore a)) NIL) :type (function (T) boolean)))
 
 (defun tag-dispatcher (name &optional (list *all-tag-dispatchers*))
-  (find name list :key #'tag-dispatcher-name))
+  (or (find name list :key #'tag-dispatcher-name)
+      (find '* list :key #'tag-dispatcher-name)))
 
 (define-setf-expander tag-dispatcher (name &optional (list '*all-tag-dispatchers*))
   (let ((nameg (gensym "NAME"))

--- a/tag-dispatcher.lisp
+++ b/tag-dispatcher.lisp
@@ -18,17 +18,20 @@
   (printer (lambda (a) (declare (ignore a)) NIL) :type (function (T) boolean)))
 
 (defun tag-dispatcher (name &optional (list *all-tag-dispatchers*))
-  (or (find name list :key #'tag-dispatcher-name)
-      (find '* list :key #'tag-dispatcher-name)))
+  (find name list :key #'tag-dispatcher-name))
 
 (define-setf-expander tag-dispatcher (name &optional (list '*all-tag-dispatchers*))
-  (let ((nameg (gensym "NAME"))
-        (disp (gensym "DISP")))
+  (let* ((nameg (gensym "NAME"))
+         (disp (gensym "DISP"))
+         (removed (gensym)))
     (values (list nameg)
             (list name)
             (list disp)
-            `(progn
-               (setf ,list (list* ,disp (remove ,nameg ,list :key #'tag-dispatcher-name)))
+            `(let ((,removed (remove ,nameg ,list :key #'tag-dispatcher-name)))
+               (setf ,list
+                     (if (eq '* ,nameg)
+                         (append ,removed (list ,disp))
+                         (list* ,disp ,removed)))
                ,disp)
             disp)))
 


### PR DESCRIPTION
As a follow up to #32, I realized today that forcing the name to be `*` made it so there can only be a single wild card dispatcher 😥. This macro allows multiple to be created with any name (still only one per special variable with the exception of *all-tag-dispatchers*).