### PR TITLE
Serialize <?xml with version first; if version not parsed, add it

### DIFF
--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -70,11 +70,14 @@
       (string-equal name "?xml"))
 
 (define-tag-parser xml-header (name)
-  (let ((attrs (consume-until (make-matcher (and (is #\?)
-                                                 (next (is #\>)))))))
-    (advance-n 2)
-    (make-xml-header *root* :attributes (with-lexer-environment (attrs)
-                                          (read-attributes)))))
+  (let* ((attrs-string (consume-until (make-matcher (and (is #\?)
+                                                         (next (is #\>))))))
+         (attrs (with-lexer-environment (attrs-string)
+                                        (read-attributes))))
+        (unless (gethash "version" attrs)
+          (setf (gethash "version" attrs) "1.0"))
+        (advance-n 2)
+        (make-xml-header *root* :attributes attrs)))
 
 ;; Special handling for CDATA sections
 (define-tag-dispatcher (cdata *tag-dispatchers* *xml-tags*) (name)

--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -70,10 +70,9 @@
       (string-equal name "?xml"))
 
 (define-tag-parser xml-header (name)
-  (let* ((attrs-string (consume-until (make-matcher (and (is #\?)
-                                                         (next (is #\>))))))
+  (let* ((attrs-string (consume-until (make-matcher (and (is #\?) (next (is #\>))))))
          (attrs (with-lexer-environment (attrs-string)
-                                        (read-attributes))))
+                  (read-attributes))))
         (unless (gethash "version" attrs)
           (setf (gethash "version" attrs) "1.0"))
         (advance-n 2)


### PR DESCRIPTION
- Fixes #34 on serialization.
- Second commit adds version="1.0" do xml-header if it was parsed and did not have this attribute. This is strictly not in #34, but as plump is *practically lenient*, this should probably be included too.

Small free form test:
``` lisp
(ql:quickload '(:plump :str))

(defun roundtrip (xml-string)
  (with-output-to-string (*standard-output*)
    (plump:serialize (plump:parse xml-string))))

(assert
  (str:starts-with-p "<?xml version=\"1.1\""
    (roundtrip       "<?xml version=\"1.1\" encoding=\"UTF-8\"?>")))
(assert
  (str:starts-with-p "<?xml version=\"1.1\""
    (roundtrip       "<?xml encoding=\"UTF-8\" version=\"1.1\"?>")))
(assert
  (str:starts-with-p "<?xml version=\"1.1\""
    (roundtrip       "<?xml version=\"1.1\"")))
(assert
  (str:starts-with-p "<?xml version=\"1.0\""
    (roundtrip       "<?xml encoding=\"UTF-8\"?>")))
```