### PR TITLE
Fix incompatible nesting-node field clone

### DIFF
--- a/dom.lisp
+++ b/dom.lisp
@@ -281,7 +281,6 @@
     (make-instance (class-of node)))
   (:method ((node nesting-node) &optional (deep T))
     (let ((clone (make-instance (class-of node)
-                                :parent (parent node)
                                 :children (make-child-array))))
       (setf (children clone) (clone-children node deep clone))
       clone))


### PR DESCRIPTION
The following code:
```
(plump:clone-node (plump:parse "<html><head></head><body><p>Hi</p></body></html>"))
```
gives the following error:
```
There is no applicable method for the generic function
  #<STANDARD-GENERIC-FUNCTION PLUMP-DOM:PARENT (1)>
when called with arguments
  (#<PLUMP-DOM:ROOT {100444A3C3}>).
```
This pull request would fix that by removing attempted assignment of the parent field. 