### PR TITLE
Wip encode attribute values

### DIFF
--- a/dom.lisp
+++ b/dom.lisp
@@ -541,7 +541,8 @@
             do (wrs " " key)
                (when val
                  (wrs "=\"")
-                 (encode-entities val *stream*)
+                 (let ((*encoding-chars* *attrval-encoding-chars*))
+                   (encode-entities val *stream*))
                  (wrs "\""))))
     (wrs "?>"))
   (:method ((node cdata))
@@ -557,7 +558,8 @@
           do (wrs " " key)
              (when val
                (wrs "=\"")
-               (encode-entities val *stream*)
+               (let ((*encoding-chars* *attrval-encoding-chars*))
+                 (encode-entities val *stream*))
                (wrs "\""))))
   (:method ((node nesting-node))
     (loop for child across (children node)

--- a/entities.lisp
+++ b/entities.lisp
@@ -371,6 +371,13 @@
     (#\> "&gt;")
     (#\" "&quot;")
     (#\& "&amp;")))
+(defparameter *attrval-encoding-chars*
+  (append
+   '((#\Tab      "&#x9;")
+     (#\Return   "&#xD;")
+     (#\Linefeed "&#xA;"))
+   *encoding-chars*))
+
 (defun write-encode-char (char stream)
   (declare (type character char)
            (optimize speed))


### PR DESCRIPTION
Please check this attempt for issue #40.

Personally, I'd prefer a keyword parameter to `encode-entities` to specify which characters to encode instead of a special variable. But this would collide with the `&optional stream` parameter. Would it be acceptable to convert the stream parameter to a keyword parameter, too?

Opinions? Suggestions?
