### PR TITLE
get-elements-by-tag-name: Preserve child order

### DIFF
--- a/dom.lisp
+++ b/dom.lisp
@@ -467,7 +467,7 @@
                             (push child finds))
                           (scanren child)))))
       (scanren node))
-    finds))
+    (nreverse finds)))
 
 (defun get-element-by-id (node id)
   (labels ((scanren (node)


### PR DESCRIPTION
The current algorithm for get-elements-by-tag-name pushes each matching element into the top of an accumulation list. This reverses the order of children by nature, producing "surprising" behavior for anyone who assumes order is preserved.

This commit "fixes" this surprise by reversing the accumulation list back to original order on return.