### PR TITLE
Change for syntax for loop/for-as-hash.

### DIFF
--- a/dom.lisp
+++ b/dom.lisp
@@ -258,7 +258,7 @@
 
 (defun clone-attributes (node)
   (let ((map (make-attribute-map)))
-    (loop for key being the hash-keys using (hash-value val) of (attributes node)
+    (loop for key being the hash-keys of (attributes node) using (hash-value val)
           do (setf (gethash key map) val))
     map))
 
@@ -271,7 +271,7 @@
   (:method ((table hash-table) &optional (deep T))
     (declare (ignore deep))
     (loop with map = (make-attribute-map)
-          for key being the hash-keys using (hash-value val) of table
+          for key being the hash-keys of table using (hash-value val)
           do (setf (gethash key map) val)
           finally (return map)))
   (:method ((node node) &optional (deep T))
@@ -533,7 +533,7 @@
       (wrs " " "version" "=\"")
       (encode-entities (gethash "version" attributes) *stream*)
       (wrs "\"")
-      (loop for key being the hash-keys using (hash-value val) of attributes
+      (loop for key being the hash-keys of attributes using (hash-value val)
             unless (string-equal key "version")
             do (wrs " " key)
                (when val
@@ -549,7 +549,7 @@
       (wrs (tag-name node)))
     (wrs " " (text node) "?>"))
   (:method ((table hash-table))
-    (loop for key being the hash-keys using (hash-value val) of table
+    (loop for key being the hash-keys of table using (hash-value val)
           do (wrs " " key)
              (when val
                (wrs "=\"")


### PR DESCRIPTION
The original code fails to compile under Lispworks; according to the CLHS, the syntax for (3 instances of) loop/for-as-hash in dom.lisp was incorrect.