### PR TITLE
Handle newline right after <script

### DIFF
--- a/special-tags.lisp
+++ b/special-tags.lisp
@@ -168,7 +168,7 @@
 
        (define-tag-parser ,tag (name)
          (let* ((closing (consume))
-                (attrs (if (char= closing #\Space)
+                (attrs (if (member closing *whitespace*)
                            (prog1 (read-attributes)
                              (setf closing (consume)))
                            (make-attribute-map))))


### PR DESCRIPTION

I was dealing with a situation where
```
  <script 
     id="foo"
      >....
  </script>
```

Was being converted to a text node. This fixes it.

(Side note: it actually converts it to a text node that looks like `&ltcript` -- notice the missing `s`. So there's another bug somewhere in the failover logic for when a node does not parse)  