### PR TITLE
Support implied end tags.

### DIFF
--- a/parser.lisp
+++ b/parser.lisp
@@ -112,6 +112,8 @@ If there are none, return NIL."
                          (setf implicit tag)))
                      (when implicit
                        (unread-throw implicit)))))
+          ;; TODO: 13.2.6.4.14 tr/caption/tbody
+          ;; etc. wrapping. Possibly some other that slipped through.
           (or
            ;; Self-closing list elements (13.2.6.4.7).
            (and (member name '("li" "dd" "dt") :test #'string-equal)


### PR DESCRIPTION
This is a somewhat frivolous interpretation of HTML Standard sections mentioning implied end tags (the respective section numbers are listed in coments). The implementation is hacking into the parser (`read-tag`) and throwing catch tags for closed tags up the stack.

Performance (not the least important thing, as I guessed) is preserved in 1.5-2 range from Plump without this PR. Tested on SBCL with 

``` lisp
(defvar page (dexador:get "https://html.spec.whatwg.org/multipage/parsing.html"))
(time (loop repeat 1000 do (plump:parse page)))
```

Without implicit end tags:

```
Evaluation took:
  65.939 seconds of real time
  65.933210 seconds of total run time (65.383450 user, 0.549760 system)
  [ Run times consist of 1.025 seconds GC time, and 64.909 seconds non-GC time. ]
  99.99% CPU
  204,143,004,686 processor cycles
  22,649,541,840 bytes consed
```

With implied end tags:

```
Evaluation took:
  108.214 seconds of real time
  108.142281 seconds of total run time (107.410723 user, 0.731558 system)
  [ Run times consist of 1.199 seconds GC time, and 106.944 seconds non-GC time. ]
  99.93% CPU
  334,864,850,988 processor cycles
  23,030,772,272 bytes consed
```

To me, the improved correctness is well worth the slowdown. I've only tested correctness on simple examples, mostly generated by [Spinneret](https://github.com/ruricolist/spinneret) for my own website. So it might actually break on some more complex cases. Hopefully it doesn't.

Fixes #50.